### PR TITLE
Fix codegen crate

### DIFF
--- a/crates/codegen-bin/Cargo.toml
+++ b/crates/codegen-bin/Cargo.toml
@@ -12,6 +12,3 @@ zksync_solidity_vk_codegen = { path = "../codegen" }
 structopt = "0.3"
 dialoguer = "0.8"
 
-[[bin]]
-name = "generate"
-path = "src/main.rs"

--- a/crates/codegen-bin/src/main.rs
+++ b/crates/codegen-bin/src/main.rs
@@ -4,17 +4,21 @@ use zksync_solidity_vk_codegen::{generate, Encoding};
 
 const DEFAULT_OUTPUT_FILE: &str = "./hardhat/contracts";
 
-const PAIRING_BN_254_FILE_PATH: &str = "./codegen/template/PairingsBn254.sol";
-const TRANSCRIPT_LIB_FILE_PATH: &str = "./codegen/template/TranscriptLib.sol";
-const UNCHECKED_MATH_FILE_PATH: &str = "./codegen/template/UncheckedMath.sol";
-const PLONK_4_VERIFIER_FILE_PATH: &str = "./codegen/template/Plonk4VerifierWithAccessToDNext.sol";
-const VEERIFIER_TEMPLATE_FILE_PATH: &str = "./codegen/template/Verifier.sol";
+const PAIRING_BN_254_FILE_PATH: &str = "PairingsBn254.sol";
+const TRANSCRIPT_LIB_FILE_PATH: &str = "TranscriptLib.sol";
+const UNCHECKED_MATH_FILE_PATH: &str = "UncheckedMath.sol";
+const PLONK_4_VERIFIER_FILE_PATH: &str = "Plonk4VerifierWithAccessToDNext.sol";
+const VEERIFIER_TEMPLATE_FILE_PATH: &str = "Verifier.sol";
 
 #[derive(StructOpt, Debug)]
 pub struct Opts {
-    /// Path to verification key(required)
+    /// Path to verification key (required)
     #[structopt(long, parse(from_os_str))]
     verification_key: PathBuf,
+    /// Path to the folder with templates (required)
+    /// Should point to the `codegen/template` directory
+    #[structopt(long, parse(from_os_str))]
+    templates_dir: PathBuf,
     /// Output directory
     #[structopt(long, parse(from_os_str), default_value = DEFAULT_OUTPUT_FILE)]
     output: PathBuf,
@@ -27,7 +31,12 @@ fn main() {
     let opts = Opts::from_args();
     println!("{:#?}", opts);
 
-    let Opts { verification_key, output, encoding } = opts;
+    let Opts {
+        verification_key,
+        output,
+        templates_dir,
+        encoding,
+    } = opts;
 
     let encoding = match encoding {
         Some(encoding) => match encoding.as_str() {
@@ -37,16 +46,18 @@ fn main() {
         None => Encoding::Default,
     };
 
+    let template_path = |file_name: &str| templates_dir.join(file_name).to_string_lossy().into_owned();
+
     generate(
         verification_key,
         output.clone(),
         encoding,
         vec![
-            VEERIFIER_TEMPLATE_FILE_PATH,
-            PLONK_4_VERIFIER_FILE_PATH,
-            TRANSCRIPT_LIB_FILE_PATH,
-            PAIRING_BN_254_FILE_PATH,
-            UNCHECKED_MATH_FILE_PATH,
+            template_path(VEERIFIER_TEMPLATE_FILE_PATH).as_ref(),
+            template_path(PLONK_4_VERIFIER_FILE_PATH).as_ref(),
+            template_path(TRANSCRIPT_LIB_FILE_PATH).as_ref(),
+            template_path(PAIRING_BN_254_FILE_PATH).as_ref(),
+            template_path(UNCHECKED_MATH_FILE_PATH).as_ref(),
         ],
     );
 


### PR DESCRIPTION
It had hardcoded paths which didn't work with the new workspace.
Now the path has to be provided explicitly (to account for the fact that you can run the binary from anywhere in the workspace).
Also the alias `generate` has been removed as it doesn't make much sense in the context of the workspace.