### PR TITLE
Bump version to 0.29.0 and add RELEASE.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,26 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+# All the packages in the workspace should have the same version
+# Important: 0.29.0 is not published right now. If you want to publish,
+# just remove this comment and go ahead.
+version = "0.29.0"
+
+[workspace.dependencies]
+# Local dependencies
+bellman = { version = "=0.29.0", path = "crates/bellman", package = "bellman_ce" }
+boojum = { version = "=0.29.0", path = "crates/boojum" }
+zksync_solidity_vk_codegen = { version = "=0.29.0", path = "crates/codegen" }
+codegen-bin = { version = "=0.29.0", path = "crates/codegen-bin" }
+cs_derive = { version = "=0.29.0", path = "crates/cs_derive" }
+ff = { version = "=0.29.0", path = "crates/ff", package = "ff_ce" }
+ff_derive_ce = { version = "=0.29.0", path = "crates/ff_derive" }
+franklin-crypto = { version = "=0.29.0", path = "crates/franklin-crypto" }
+pairing = { version = "=0.29.0", path = "crates/pairing", package = "pairing_ce" }
+rescue_poseidon = { version = "=0.29.0", path = "crates/rescue-poseidon" }
+snark_wrapper = { version = "=0.29.0", path = "crates/snark-wrapper" }
+
 [profile.release]
 debug = true
 codegen-units = 1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,29 @@
+# Release process
+
+If you want to release the packages on crates.io, follow this process:
+
+1. Install `cargo workspaces`: `cargo install cargo-workspaces`
+2. Create a new branch to prepare a release.
+3. Change versions in the `Cargo.toml`:
+  - `version` in `[workspace.package]`
+  - `version` in `[workspace.dependencies]` for all the relevant crates.
+4. Run `cargo build`. It must succeed.
+5. Commit changes.
+6. Run `cargo ws publish --dry-run`. Check the output. It might fail, but it might be OK.
+  - `error: config value 'http.cainfo' is not set` can be ignored.
+  - There might be warnings, this is OK.
+  - There might be errors related to the version resolution, e.g. `failed to select a version`
+    (in particular, for `zkevm_test_harness`). It's due to a bug in cargo workspaces.
+    Check that the packages it complains about actually have the specified version, and if so,
+    it's safe to proceed.
+7. Create a PR named `crates.io: Release <version>`. Get a review and merge it.
+8. From the main branch _after_ you merge it, run `cargo ws publish --publish-as-is --allow-dirty`.
+  - The `--publish-as-is` argument skips the versioning step, which you already did before.
+  - The `--allow-dirty` argument is required, because `cargo ws` temporarily removes dev-dependencies
+    during publishing.
+  - Important: if something fails and you have to do changes to the code, it's safe to run the same
+    command again. `cargo ws` will skip already published packages.
+9. If something goes wrong, see recommendations below.
+10. If everything is OK, create a tag: `git tag v<version>`, e.g. `git tag v0.150.4`
+11. `git push --tags`
+12. Go to the Releases in the GitHUb, and create a release for published version.

--- a/crates/bellman/Cargo.toml
+++ b/crates/bellman/Cargo.toml
@@ -6,14 +6,14 @@ homepage = "https://github.com/matter-labs/bellman"
 license = "MIT/Apache-2.0"
 name = "bellman_ce"
 repository = "https://github.com/matter-labs/bellman"
-version = "0.8.0"
+version.workspace = true
 edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "lib", "staticlib"]
 
 [dependencies]
-pairing = {package = "pairing_ce", version = "=0.28.6", path = "../pairing" }
+pairing.workspace = true
 
 rand = "0.4"
 bit-vec = { version = "0.6", features = ["serde"] }

--- a/crates/boojum/Cargo.toml
+++ b/crates/boojum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boojum"
-version = "0.2.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -12,8 +12,8 @@ description = "Boojum cryptographic library"
 exclude = [ "profiling-target" ]
 
 [dependencies]
-cs_derive = { version = "=0.2.2", path = "../cs_derive" }
-pairing = { package = "pairing_ce", version = "=0.28.6", path = "../pairing" }
+cs_derive.workspace = true
+pairing.workspace = true
 
 derivative = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/codegen-bin/Cargo.toml
+++ b/crates/codegen-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codegen-bin"
-version = "0.1.0"
+version.workspace = true
 edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zksync_solidity_vk_codegen = { path = "../codegen" }
+zksync_solidity_vk_codegen.workspace = true
 structopt = "0.3"
 dialoguer = "0.8"
 

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_solidity_vk_codegen"
-version = "0.1.0"
+version.workspace = true
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "ZKsync solidity codegen for vks"
@@ -8,8 +8,8 @@ description = "ZKsync solidity codegen for vks"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-franklin-crypto = { version = "=0.2.2", features = ["plonk"], path = "../franklin-crypto" }
-rescue_poseidon = { version = "=0.5.2", path = "../rescue-poseidon" }
+franklin-crypto = { workspace = true, features = ["plonk"] }
+rescue_poseidon.workspace = true
 
 handlebars = "3.5.5"
 serde = "1"

--- a/crates/cs_derive/Cargo.toml
+++ b/crates/cs_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cs_derive"
-version = "0.2.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/crates/ff/Cargo.toml
+++ b/crates/ff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff_ce"
-version = "0.14.3"
+version.workspace = true
 authors = ["Sean Bowe <ewillbefull@gmail.com>",
     "Alex Gluchowski <alex@gluchowski.net>",
     "Alex Vlasov <alex.m.vlasov@gmail.com>"]
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-ff_derive_ce = { version = "0.11", optional = true, path = "../ff_derive" }
+ff_derive_ce = { workspace = true, optional = true }
 
 byteorder = "1"
 rand = "0.4"

--- a/crates/ff_derive/Cargo.toml
+++ b/crates/ff_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff_derive_ce"
-version = "0.11.2"
+version.workspace = true
 authors = ["Sean Bowe <ewillbefull@gmail.com>",    
     "Alex Gluchowski <alex@gluchowski.net>",
     "Alex Vlasov <alex.m.vlasov@gmail.com>"]

--- a/crates/franklin-crypto/Cargo.toml
+++ b/crates/franklin-crypto/Cargo.toml
@@ -4,7 +4,7 @@ description = "Cryptographic library for SNARK gadgets"
 homepage = "https://github.com/matter-labs/franklin-crypto"
 license = "MIT/Apache-2.0"
 name = "franklin-crypto"
-version = "0.2.2"
+version.workspace = true
 edition = "2015"
 
 [lib]
@@ -17,8 +17,8 @@ plonk = ["bellman/plonk"]
 allocator = ["bellman/allocator"]
 
 [dependencies]
-boojum = { version = "=0.2.2", path = "../boojum" }
-bellman = { package = "bellman_ce", version = "=0.8.0", path = "../bellman" }
+boojum.workspace = true
+bellman.workspace = true
 
 derivative = "2"
 rand = "0.4"

--- a/crates/pairing/Cargo.toml
+++ b/crates/pairing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pairing_ce"
-version = "0.28.6"
+version.workspace = true
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Jack Grigg <jack@z.cash>",
@@ -16,7 +16,7 @@ repository = "https://github.com/matter-labs/pairing"
 edition = "2018"
 
 [dependencies]
-ff = { package = "ff_ce", version = "0.14.*", features = ["derive"], path = "../ff" }
+ff = { workspace = true, features = ["derive"] }
 
 rand = "0.4"
 byteorder = "1"

--- a/crates/rescue-poseidon/Cargo.toml
+++ b/crates/rescue-poseidon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rescue_poseidon"
 description = "Sponge construction based Algebraic Hash Functions"
 keywords = ["poseidon", "rescue", "sponge"]
-version = "0.5.2"
+version.workspace = true
 authors = ["Sait Imamoglu <si@matterlabs.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-franklin_crypto = { package = "franklin-crypto", features = ["plonk"], version = "=0.2.2", path = "../franklin-crypto" }
+franklin-crypto = { workspace = true, features = ["plonk"]  }
 
 derivative = "2"
 typemap_rev = "0.3"

--- a/crates/snark-wrapper/Cargo.toml
+++ b/crates/snark-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark_wrapper"
-version = "0.1.2"
+version.workspace = true
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -13,7 +13,7 @@ description = "ZKsync snark wrapper"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rescue_poseidon = { version = "=0.5.2", path = "../rescue-poseidon" }
+rescue_poseidon.workspace = true
 
 derivative = "2"
 rand = "0.4"


### PR DESCRIPTION
- Sets a single version for all the crate: 0.29.0. It's the least version that would work for all the crates. With that, we can always release the whole workspace.
- Sets the local dependencies to use `workspace = true`.
- Adds RELEASE.md