### PR TITLE
fix: Fix hard static analysis errors

### DIFF
--- a/crates/bellman/src/lib.rs
+++ b/crates/bellman/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code, unused_imports, unused_mut, unused_variables, unused_macros, unused_assignments, unreachable_patterns)]
 #![cfg_attr(feature = "allocator", feature(allocator_api))]
+#![allow(clippy::needless_borrow, clippy::needless_borrows_for_generic_args)]
 
 #[macro_use]
 extern crate cfg_if;

--- a/crates/bellman/src/log.rs
+++ b/crates/bellman/src/log.rs
@@ -1,4 +1,4 @@
-#[allow(unused_macros)]
+#[allow(clippy::needless_borrow)]
 
 cfg_if! {
     if #[cfg(feature = "nolog")] {

--- a/crates/bellman/src/plonk/better_better_cs/proof/mod.rs
+++ b/crates/bellman/src/plonk/better_better_cs/proof/mod.rs
@@ -657,6 +657,7 @@ impl<E: Engine, P: PlonkConstraintSystemParams<E>, MG: MainGate<E>, S: Synthesis
             grand_products_protos_with_gamma.push(p);
         }
 
+        #[allow(clippy::redundant_locals)]
         let required_domain_size = required_domain_size;
 
         let domain = Domain::new_for_size(required_domain_size as u64)?;

--- a/crates/bellman/src/plonk/polynomials/mod.rs
+++ b/crates/bellman/src/plonk/polynomials/mod.rs
@@ -740,8 +740,12 @@ impl<F: PrimeField> Polynomial<F, Coefficients> {
 
         // let mut final_values = vec![F::zero(); new_size];
 
+        #[allow(clippy::uninit_vec)] // Data is initialized below without being read
         let mut final_values = Vec::with_capacity(new_size);
-        unsafe { final_values.set_len(new_size) };
+        #[allow(clippy::uninit_vec)] // Data is initialized below without being read
+        unsafe {
+            final_values.set_len(new_size)
+        };
 
         // copy here is more complicated: to have the value in a natural order
         // one has to use coset_idx to address the result element
@@ -1272,27 +1276,14 @@ impl<F: PrimeField> Polynomial<F, Values> {
 
         assert!(subset_factor.is_power_of_two());
 
-        let current_size = self.coeffs.len();
-        let new_size = current_size / subset_factor;
-
-        let mut result = Vec::with_capacity(new_size);
-        unsafe { result.set_len(new_size) };
-
         // copy elements. If factor is 2 then non-reversed we would output only elements that are == 0 mod 2
         // If factor is 2 and we are bit-reversed - we need to only output first half of the coefficients
         // If factor is 4 then we need to output only the first 4th part
         // if factor is 8 - only the first 8th part
+        let current_size = self.coeffs.len();
+        let new_size = current_size / subset_factor;
 
-        let start = 0;
-        let end = new_size;
-
-        result.copy_from_slice(&self.coeffs[start..end]);
-
-        // unsafe { result.set_len(new_size)};
-        // let copy_to_start_pointer: *mut F = result[..].as_mut_ptr();
-        // let copy_from_start_pointer: *const F = self.coeffs[start..end].as_ptr();
-
-        // unsafe { std::ptr::copy_nonoverlapping(copy_from_start_pointer, copy_to_start_pointer, new_size) };
+        let result = self.coeffs[..new_size].to_vec();
 
         Polynomial::from_values(result)
     }
@@ -2087,8 +2078,12 @@ impl<F: PartialTwoBitReductionField> Polynomial<F, Coefficients> {
 
         // let mut results = vec![self.coeffs.clone(); factor];
 
+        #[allow(clippy::uninit_vec)] // Data is initialized below without being read
         let mut result = Vec::with_capacity(new_size);
-        unsafe { result.set_len(new_size) };
+        #[allow(clippy::uninit_vec)] // Data is initialized below without being read
+        unsafe {
+            result.set_len(new_size)
+        };
 
         let r = &mut result[..] as *mut [F];
 
@@ -2274,8 +2269,12 @@ impl<F: PrimeField> Polynomial<F, Coefficients> {
 
         // let mut results = vec![self.coeffs.clone(); factor];
 
+        #[allow(clippy::uninit_vec)] // Data is initialized below without being read
         let mut result = Vec::with_capacity(new_size);
-        unsafe { result.set_len(new_size) };
+        #[allow(clippy::uninit_vec)] // Data is initialized below without being read
+        unsafe {
+            result.set_len(new_size)
+        };
 
         let r = &mut result[..] as *mut [F];
 

--- a/crates/bellman/src/plonk/transparent_engine/proth.rs
+++ b/crates/bellman/src/plonk/transparent_engine/proth.rs
@@ -4,6 +4,7 @@ use crate::ff::*;
 #[derive(Copy, Clone, PartialEq, Eq, Default, Hash, ::serde::Serialize, ::serde::Deserialize)]
 pub struct FrRepr(pub [u64; 4usize]);
 
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Hash, ::serde::Serialize, ::serde::Deserialize)]
 pub struct Fr(FrRepr);
 

--- a/crates/boojum/src/lib.rs
+++ b/crates/boojum/src/lib.rs
@@ -1,7 +1,7 @@
 // Allowed lints
 // Whenever add an item here, please write a short yet meaningful comment on why so.
 #![allow(
-    clippy::incorrect_clone_impl_on_copy_type, // False positives in derivative: https://github.com/mcarton/rust-derivative/issues/112
+    clippy::non_canonical_clone_impl, // False positives in derivative: https://github.com/mcarton/rust-derivative/issues/112
     clippy::bool_comparison, // Explicitness is good in critical contexts.
     clippy::mut_from_ref, // Triggers on unsafe functions (e.g. ones using `UnsafeCell`).
     clippy::type_complexity, // Many types in this create are inherently complex.

--- a/crates/codegen/src/generate.rs
+++ b/crates/codegen/src/generate.rs
@@ -235,7 +235,7 @@ fn render(vars: TemplateVars, vk: VerificationKey<Bn256, DummyCircuit>, output_d
 
         let rendered = handlebars.render("contract", &map.inner).unwrap();
 
-        writer.write(rendered.as_bytes()).expect("must write to file");
+        writer.write_all(rendered.as_bytes()).expect("must write to file");
     }
 }
 

--- a/crates/pairing/benches/bls12_381/ec.rs
+++ b/crates/pairing/benches/bls12_381/ec.rs
@@ -1,8 +1,8 @@
 mod g1 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing::bls12_381::*;
-    use pairing::CurveProjective;
+    use pairing_ce::bls12_381::*;
+    use pairing_ce::CurveProjective;
 
     #[bench]
     fn bench_g1_mul_assign(b: &mut ::test::Bencher) {
@@ -59,8 +59,8 @@ mod g1 {
 mod g2 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing::bls12_381::*;
-    use pairing::CurveProjective;
+    use pairing_ce::bls12_381::*;
+    use pairing_ce::CurveProjective;
 
     #[bench]
     fn bench_g2_mul_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fq.rs
+++ b/crates/pairing/benches/bls12_381/fq.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing::bls12_381::*;
+use pairing_ce::bls12_381::*;
 
 #[bench]
 fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fq12.rs
+++ b/crates/pairing/benches/bls12_381/fq12.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::Field;
-use pairing::bls12_381::*;
+use pairing_ce::bls12_381::*;
 
 #[bench]
 fn bench_fq12_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fq2.rs
+++ b/crates/pairing/benches/bls12_381/fq2.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, SqrtField};
-use pairing::bls12_381::*;
+use pairing_ce::bls12_381::*;
 
 #[bench]
 fn bench_fq2_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fr.rs
+++ b/crates/pairing/benches/bls12_381/fr.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing::bls12_381::*;
+use pairing_ce::bls12_381::*;
 
 #[bench]
 fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/mod.rs
+++ b/crates/pairing/benches/bls12_381/mod.rs
@@ -6,8 +6,8 @@ mod fr;
 
 use rand::{Rand, SeedableRng, XorShiftRng};
 
-use pairing::bls12_381::*;
-use pairing::{CurveAffine, Engine};
+use pairing_ce::bls12_381::*;
+use pairing_ce::{CurveAffine, Engine};
 
 #[bench]
 fn bench_pairing_g1_preparation(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/ec.rs
+++ b/crates/pairing/benches/bn256/ec.rs
@@ -1,8 +1,8 @@
 mod g1 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing::bn256::*;
-    use pairing::CurveProjective;
+    use pairing_ce::bn256::*;
+    use pairing_ce::CurveProjective;
 
     #[bench]
     fn bench_g1_mul_assign(b: &mut ::test::Bencher) {
@@ -59,8 +59,8 @@ mod g1 {
 mod g2 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing::bls12_381::*;
-    use pairing::CurveProjective;
+    use pairing_ce::bls12_381::*;
+    use pairing_ce::CurveProjective;
 
     #[bench]
     fn bench_g2_mul_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fq.rs
+++ b/crates/pairing/benches/bn256/fq.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing::bn256::*;
+use pairing_ce::bn256::*;
 
 #[bench]
 fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fq12.rs
+++ b/crates/pairing/benches/bn256/fq12.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::Field;
-use pairing::bn256::*;
+use pairing_ce::bn256::*;
 
 #[bench]
 fn bench_fq12_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fq2.rs
+++ b/crates/pairing/benches/bn256/fq2.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, SqrtField};
-use pairing::bn256::*;
+use pairing_ce::bn256::*;
 
 #[bench]
 fn bench_fq2_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fr.rs
+++ b/crates/pairing/benches/bn256/fr.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing::bn256::*;
+use pairing_ce::bn256::*;
 
 #[bench]
 fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/mod.rs
+++ b/crates/pairing/benches/bn256/mod.rs
@@ -6,8 +6,8 @@ mod fr;
 
 use rand::{Rand, SeedableRng, XorShiftRng};
 
-use pairing::bn256::*;
-use pairing::{CurveAffine, Engine};
+use pairing_ce::bn256::*;
+use pairing_ce::{CurveAffine, Engine};
 
 #[bench]
 fn bench_pairing_g1_preparation(b: &mut ::test::Bencher) {

--- a/crates/pairing/src/lib.rs
+++ b/crates/pairing/src/lib.rs
@@ -1,13 +1,4 @@
-// `clippy` is a code linting tool for improving code quality by catching
-// common mistakes or strange code patterns. If the `cargo-clippy` feature
-// is provided, all compiler warnings are prohibited.
-#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
-// #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
-// #![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-// #![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
-// #![cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
-// #![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
-// #![cfg_attr(feature = "cargo-clippy", allow(write_literal))]
+#![allow(clippy::too_many_arguments, clippy::needless_borrows_for_generic_args)]
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 // Asm is only available on nightly, with this unstable feature


### PR DESCRIPTION
- Fixes all the "red" errors (deny by default) observable in the monorepo.
- Fixes/silences _some_ of the "yellow" errors (there are just too many for a single PR).

The ultimate goal is to enable clippy in CI.