### PR TITLE
feat!: Rename crypto crates and properly set metadata

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -27,6 +27,14 @@ under [MIT][pairing-mit] and [Apache 2.0][pairing-apache] licenses.
 [pairing-mit]: https://github.com/zkcrypto/pairing/blob/17973bdd64a44a4829dd6b150f2d54246709b1da/LICENSE-MIT
 [pairing-apache]: https://github.com/zkcrypto/pairing/blob/17973bdd64a44a4829dd6b150f2d54246709b1da/LICENSE-APACHE
 
+## sapling-crypto
+
+[sapling: Zcash "Sapling" cryptography](https://github.com/zcash/sapling-crypto) dual-licensed under
+[MIT][sapling-mit] and [Apache 2.0][sapling-apache] licenses.
+
+[sapling-mit]: https://github.com/zcash/sapling-crypto/blob/984a08897644af67754a12ec13a7d7ccad5fa0d3/LICENSE-MIT
+[sapling-apache]: https://github.com/zcash/sapling-crypto/blob/984a08897644af67754a12ec13a7d7ccad5fa0d3/LICENSE-APACHE
+
 ## plonky2
 
 [plonky2: Plonky2, a SNARK implementation based on techniques from PLONK and FRI](https://github.com/mir-protocol/plonky2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,25 @@ resolver = "2"
 # Important: 0.29.0 is not published right now. If you want to publish,
 # just remove this comment and go ahead.
 version = "0.29.0"
+edition = "2021"
+authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
+homepage = "https://zksync.io/"
+repository = "https://github.com/matter-labs/zksync-crypto/"
+license = "MIT OR Apache-2.0"
+keywords = ["blockchain", "zksync"]
+categories = ["cryptography"]
 
 [workspace.dependencies]
 # Local dependencies
-bellman = { version = "=0.29.0", path = "crates/bellman", package = "bellman_ce" }
+bellman = { version = "=0.29.0", path = "crates/bellman", package = "zksync_bellman" }
 boojum = { version = "=0.29.0", path = "crates/boojum" }
 zksync_solidity_vk_codegen = { version = "=0.29.0", path = "crates/codegen" }
 codegen-bin = { version = "=0.29.0", path = "crates/codegen-bin" }
-cs_derive = { version = "=0.29.0", path = "crates/cs_derive" }
-ff = { version = "=0.29.0", path = "crates/ff", package = "ff_ce" }
-ff_derive_ce = { version = "=0.29.0", path = "crates/ff_derive" }
+cs_derive = { version = "=0.29.0", path = "crates/cs_derive", package = "zksync_cs_derive" }
+ff = { version = "=0.29.0", path = "crates/ff", package = "zksync_ff" }
+ff_derive = { version = "=0.29.0", path = "crates/ff_derive", package = "zksync_ff_derive" }
 franklin-crypto = { version = "=0.29.0", path = "crates/franklin-crypto" }
-pairing = { version = "=0.29.0", path = "crates/pairing", package = "pairing_ce" }
+pairing = { version = "=0.29.0", path = "crates/pairing", package = "zksync_pairing" }
 rescue_poseidon = { version = "=0.29.0", path = "crates/rescue-poseidon" }
 snark_wrapper = { version = "=0.29.0", path = "crates/snark-wrapper" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ resolver = "2"
 
 [workspace.package]
 # All the packages in the workspace should have the same version
-# Important: 0.29.0 is not published right now. If you want to publish,
-# just remove this comment and go ahead.
 version = "0.29.0"
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,42 @@
 # Release process
 
+## Automatic releases
+
+We use [release-please](https://github.com/googleapis/release-please) to manage releases, as well
+as a custom automation to publish releases on [crates.io](https://crates.io/).
+
+Any pull request name must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+specification, and then, based on the PR titles, a release pull request will be created, which
+will take care of changelog generation.
+
+Important: only `fix` and `feat` labels will trigger a release PR creation. So, if a `chore` or `ci`
+PR will be merged right after release, the PR will not be created (they _will_ be included into a release,
+if a release PR exists, but they won't trigger PR creation or appear in the changelog). If you want to make
+sure that the change will trigger a release PR, mark the PR as `fix` or `feat`.
+
+By default, a patch version will be bumped. If you want to bump a minor version, mark the PR as breaking with
+an exclamation point, e.g. `feat!` or `fix!`.
+
+It is recommended that each PR has a component mentioned, e.g. `feat(component): Change added`.
+
+Once release PR is merged, it will be published to `crates.io`, and a notification will be sent to Slack.
+
+## Manual releases
+
+> [!WARNING]  
+> Manual releases are discouraged, and should only be used as a last resort measure.
+> Discuss the manual release with the team beforehand and prepare a plan.
+> It is very likely that manual release will interfere with `release-please` configuration,
+> which will have to be fixed manually as well.
+>
+> Additionally, if the release was created, but wasn't published, you will only need a subset
+> of the actions listed below (e.g. if the it failed due to a transient error, you just need to
+> publish code without creating any tags; but if the release can't be published, it's better to
+> remove it, fix the issue, and try releasing again via automation).
+
+> [!CAUTION]
+> Never release code that does not correspond to any tag.
+
 If you want to release the packages on crates.io, follow this process:
 
 1. Install `cargo workspaces`: `cargo install cargo-workspaces`

--- a/crates/bellman/Cargo.toml
+++ b/crates/bellman/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-authors = ["Sean Bowe <ewillbefull@gmail.com>", "Alex Vlasov <alex.m.vlasov@gmail.com>", "Alex Gluchowski <alex@gluchowski.net"]
-description = "zk-SNARK library"
-documentation = "https://github.com/matter-labs/bellman"
-homepage = "https://github.com/matter-labs/bellman"
-license = "MIT/Apache-2.0"
-name = "bellman_ce"
-repository = "https://github.com/matter-labs/bellman"
-version.workspace = true
+name = "zksync_bellman"
+description = "zk-SNARK library, based on bellman"
 edition = "2018"
+version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib", "staticlib"]

--- a/crates/bellman/tests/mimc.rs
+++ b/crates/bellman/tests/mimc.rs
@@ -5,20 +5,20 @@ use rand::{thread_rng, Rng};
 use std::time::{Duration, Instant};
 
 // Bring in some tools for using pairing-friendly curves
-use bellman_ce::pairing::Engine;
+use zksync_bellman::pairing::Engine;
 
-use bellman_ce::pairing::ff::Field;
+use zksync_bellman::pairing::ff::Field;
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.
-use bellman_ce::pairing::bls12_381::Bls12;
+use zksync_bellman::pairing::bls12_381::Bls12;
 
-use bellman_ce::pairing::bn256::Bn256;
+use zksync_bellman::pairing::bn256::Bn256;
 
 // We'll use these interfaces to construct our circuit.
-use bellman_ce::{Circuit, ConstraintSystem, SynthesisError};
+use zksync_bellman::{Circuit, ConstraintSystem, SynthesisError};
 
 // We're going to use the Groth16 proving system.
-use bellman_ce::groth16::{create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof, Proof};
+use zksync_bellman::groth16::{create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof, Proof};
 
 // const MIMC_ROUNDS: usize = 322;
 
@@ -27,8 +27,8 @@ const MIMC_ROUNDS: usize = 1000000;
 #[cfg(feature = "marlin")]
 #[test]
 fn test_bench_marlin_prover() {
-    use bellman_ce::marlin::prover::test_over_engine_and_circuit_with_proving_key;
-    use bellman_ce::pairing::bn256::Bn256;
+    use zksync_bellman::marlin::prover::test_over_engine_and_circuit_with_proving_key;
+    use zksync_bellman::pairing::bn256::Bn256;
     {
         // This may not be cryptographically safe, use
         // `OsRng` (for example) in production software.
@@ -55,8 +55,8 @@ fn test_bench_marlin_prover() {
 #[cfg(feature = "marlin")]
 #[test]
 fn test_create_marlin_proving_key() {
-    use bellman_ce::marlin::prover::create_test_keys;
-    use bellman_ce::pairing::bn256::Bn256;
+    use zksync_bellman::marlin::prover::create_test_keys;
+    use zksync_bellman::pairing::bn256::Bn256;
     {
         // This may not be cryptographically safe, use
         // `OsRng` (for example) in production software.
@@ -349,7 +349,7 @@ fn test_mimc_bn256() {
 #[test]
 #[ignore] // TODO(ignored-test): Timeout.
 fn test_mimc_transpilation_into_plonk() {
-    use bellman_ce::plonk::adaptor::alternative::Transpiler;
+    use zksync_bellman::plonk::adaptor::alternative::Transpiler;
     // This may not be cryptographically safe, use
     // `OsRng` (for example) in production software.
     let rng = &mut thread_rng();

--- a/crates/boojum/Cargo.toml
+++ b/crates/boojum/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "boojum"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-boojum"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Boojum cryptographic library"
 exclude = [ "profiling-target" ]
 

--- a/crates/codegen-bin/Cargo.toml
+++ b/crates/codegen-bin/Cargo.toml
@@ -2,7 +2,12 @@
 name = "codegen-bin"
 version.workspace = true
 edition = "2018"
-license = "MIT OR Apache-2.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -2,7 +2,12 @@
 name = "zksync_solidity_vk_codegen"
 version.workspace = true
 edition = "2018"
-license = "MIT OR Apache-2.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync solidity codegen for vks"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/cs_derive/Cargo.toml
+++ b/crates/cs_derive/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "cs_derive"
+name = "zksync_cs_derive"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/era-boojum"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Derive macro for boojum crate"
 
 [dependencies]

--- a/crates/ff/Cargo.toml
+++ b/crates/ff/Cargo.toml
@@ -1,22 +1,21 @@
 [package]
-name = "ff_ce"
+name = "zksync_ff"
 version.workspace = true
-authors = ["Sean Bowe <ewillbefull@gmail.com>",
-    "Alex Gluchowski <alex@gluchowski.net>",
-    "Alex Vlasov <alex.m.vlasov@gmail.com>"]
-description = "Library for building and interfacing with finite fields"
-documentation = "https://docs.rs/ff/"
-homepage = "https://github.com/matter-labs/ff"
-license = "MIT/Apache-2.0"
-repository = "https://github.com/matter-labs/ff"
 edition = "2018"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Library for building and interfacing with finite fields, based on ff"
 exclude = [
     "tester",
     "asm_tester"
 ]
 
 [dependencies]
-ff_derive_ce = { workspace = true, optional = true }
+ff_derive = { workspace = true, optional = true }
 
 byteorder = "1"
 rand = "0.4"
@@ -25,5 +24,5 @@ serde = "1"
 
 [features]
 default = []
-derive = ["ff_derive_ce"]
-asm_derive = ["derive", "ff_derive_ce/asm"]
+derive = ["ff_derive"]
+asm_derive = ["derive", "ff_derive/asm"]

--- a/crates/ff/src/lib.rs
+++ b/crates/ff/src/lib.rs
@@ -10,10 +10,10 @@ pub mod hex {
 
 #[cfg(feature = "derive")]
 #[macro_use]
-extern crate ff_derive_ce;
+extern crate ff_derive;
 
 #[cfg(feature = "derive")]
-pub use ff_derive_ce::*;
+pub use ff_derive::*;
 
 use std::error::Error;
 use std::fmt;

--- a/crates/ff_derive/Cargo.toml
+++ b/crates/ff_derive/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
-name = "ff_derive_ce"
+name = "zksync_ff_derive"
 version.workspace = true
-authors = ["Sean Bowe <ewillbefull@gmail.com>",    
-    "Alex Gluchowski <alex@gluchowski.net>",
-    "Alex Vlasov <alex.m.vlasov@gmail.com>"]
-description = "Procedural macro library used to build custom prime field implementations"
-documentation = "https://docs.rs/ff/"
-homepage = "https://github.com/matter-labs/ff"
-license = "MIT/Apache-2.0"
-repository = "https://github.com/matter-labs/ff"
 edition = "2018"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Procedural macro library for zksync_ff, based on ff_derive"
 
 [lib]
 proc-macro = true

--- a/crates/franklin-crypto/Cargo.toml
+++ b/crates/franklin-crypto/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
-authors = ["Sean Bowe <sean@z.cash>", "Alex Vlasov <alex.m.vlasov@gmail.com>", "Alex Gluchowski <alex@gluchowski.net>"]
-description = "Cryptographic library for SNARK gadgets"
-homepage = "https://github.com/matter-labs/franklin-crypto"
-license = "MIT/Apache-2.0"
 name = "franklin-crypto"
 version.workspace = true
 edition = "2015"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Cryptographic library for SNARK gadgets, based on sapling-crypto"
 
 [lib]
 crate-type = ["lib", "staticlib"]

--- a/crates/pairing/Cargo.toml
+++ b/crates/pairing/Cargo.toml
@@ -1,19 +1,14 @@
 [package]
-name = "pairing_ce"
+name = "zksync_pairing"
 version.workspace = true
-authors = [
-    "Sean Bowe <ewillbefull@gmail.com>",
-    "Jack Grigg <jack@z.cash>",
-    "Alex Vlasov <alex.m.vlasov@gmail.com>",
-    "Alex Gluchowski <alex@gluchowski.net>"
-]
-license = "MIT/Apache-2.0"
-
-description = "Pairing-friendly elliptic curve library"
-documentation = "https://docs.rs/pairing_ce/"
-homepage = "https://github.com/matter-labs/pairing"
-repository = "https://github.com/matter-labs/pairing"
 edition = "2018"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Pairing-friendly elliptic curve library, based on pairing crate"
 
 [dependencies]
 ff = { workspace = true, features = ["derive"] }

--- a/crates/pairing/benches/bls12_381/ec.rs
+++ b/crates/pairing/benches/bls12_381/ec.rs
@@ -1,8 +1,8 @@
 mod g1 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing_ce::bls12_381::*;
-    use pairing_ce::CurveProjective;
+    use zksync_pairing::bls12_381::*;
+    use zksync_pairing::CurveProjective;
 
     #[bench]
     fn bench_g1_mul_assign(b: &mut ::test::Bencher) {
@@ -59,8 +59,8 @@ mod g1 {
 mod g2 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing_ce::bls12_381::*;
-    use pairing_ce::CurveProjective;
+    use zksync_pairing::bls12_381::*;
+    use zksync_pairing::CurveProjective;
 
     #[bench]
     fn bench_g2_mul_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fq.rs
+++ b/crates/pairing/benches/bls12_381/fq.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing_ce::bls12_381::*;
+use zksync_pairing::bls12_381::*;
 
 #[bench]
 fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fq12.rs
+++ b/crates/pairing/benches/bls12_381/fq12.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::Field;
-use pairing_ce::bls12_381::*;
+use zksync_pairing::bls12_381::*;
 
 #[bench]
 fn bench_fq12_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fq2.rs
+++ b/crates/pairing/benches/bls12_381/fq2.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, SqrtField};
-use pairing_ce::bls12_381::*;
+use zksync_pairing::bls12_381::*;
 
 #[bench]
 fn bench_fq2_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/fr.rs
+++ b/crates/pairing/benches/bls12_381/fr.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing_ce::bls12_381::*;
+use zksync_pairing::bls12_381::*;
 
 #[bench]
 fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bls12_381/mod.rs
+++ b/crates/pairing/benches/bls12_381/mod.rs
@@ -6,8 +6,8 @@ mod fr;
 
 use rand::{Rand, SeedableRng, XorShiftRng};
 
-use pairing_ce::bls12_381::*;
-use pairing_ce::{CurveAffine, Engine};
+use zksync_pairing::bls12_381::*;
+use zksync_pairing::{CurveAffine, Engine};
 
 #[bench]
 fn bench_pairing_g1_preparation(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/ec.rs
+++ b/crates/pairing/benches/bn256/ec.rs
@@ -1,8 +1,8 @@
 mod g1 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing_ce::bn256::*;
-    use pairing_ce::CurveProjective;
+    use zksync_pairing::bn256::*;
+    use zksync_pairing::CurveProjective;
 
     #[bench]
     fn bench_g1_mul_assign(b: &mut ::test::Bencher) {
@@ -59,8 +59,8 @@ mod g1 {
 mod g2 {
     use rand::{Rand, SeedableRng, XorShiftRng};
 
-    use pairing_ce::bls12_381::*;
-    use pairing_ce::CurveProjective;
+    use zksync_pairing::bls12_381::*;
+    use zksync_pairing::CurveProjective;
 
     #[bench]
     fn bench_g2_mul_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fq.rs
+++ b/crates/pairing/benches/bn256/fq.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing_ce::bn256::*;
+use zksync_pairing::bn256::*;
 
 #[bench]
 fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fq12.rs
+++ b/crates/pairing/benches/bn256/fq12.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::Field;
-use pairing_ce::bn256::*;
+use zksync_pairing::bn256::*;
 
 #[bench]
 fn bench_fq12_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fq2.rs
+++ b/crates/pairing/benches/bn256/fq2.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, SqrtField};
-use pairing_ce::bn256::*;
+use zksync_pairing::bn256::*;
 
 #[bench]
 fn bench_fq2_add_assign(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/fr.rs
+++ b/crates/pairing/benches/bn256/fr.rs
@@ -1,7 +1,7 @@
 use rand::{Rand, SeedableRng, XorShiftRng};
 
 use ff::{Field, PrimeField, PrimeFieldRepr, SqrtField};
-use pairing_ce::bn256::*;
+use zksync_pairing::bn256::*;
 
 #[bench]
 fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/bn256/mod.rs
+++ b/crates/pairing/benches/bn256/mod.rs
@@ -6,8 +6,8 @@ mod fr;
 
 use rand::{Rand, SeedableRng, XorShiftRng};
 
-use pairing_ce::bn256::*;
-use pairing_ce::{CurveAffine, Engine};
+use zksync_pairing::bn256::*;
+use zksync_pairing::{CurveAffine, Engine};
 
 #[bench]
 fn bench_pairing_g1_preparation(b: &mut ::test::Bencher) {

--- a/crates/pairing/benches/pairing_benches.rs
+++ b/crates/pairing/benches/pairing_benches.rs
@@ -1,9 +1,9 @@
 #![feature(test)]
 
 extern crate ff;
-extern crate pairing_ce;
 extern crate rand;
 extern crate test;
+extern crate zksync_pairing;
 
 mod bls12_381;
 mod bn256;

--- a/crates/rescue-poseidon/Cargo.toml
+++ b/crates/rescue-poseidon/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "rescue_poseidon"
-description = "Sponge construction based Algebraic Hash Functions"
-keywords = ["poseidon", "rescue", "sponge"]
 version.workspace = true
-authors = ["Sait Imamoglu <si@matterlabs.dev>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords = ["poseidon", "rescue", "sponge"]
+categories.workspace = true
+description = "Sponge construction based Algebraic Hash Functions"
 
 [dependencies]
 franklin-crypto = { workspace = true, features = ["plonk"]  }

--- a/crates/snark-wrapper/Cargo.toml
+++ b/crates/snark-wrapper/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 name = "snark_wrapper"
 version.workspace = true
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "ZKsync snark wrapper"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 rescue_poseidon.workspace = true


### PR DESCRIPTION
- Renames crates with confusing/misleading names, e.g. forks with `_ce` postfix were renamed to have `zksync_` prefix. Example: `bellman_ce` -> `zksync_bellman`.
- Acknowledges sapling-crypto.
- Sets the unified metadata in `Cargo.toml`.
- Modifies `RELEASE.md`.

> [!WARNING]
> This is a breaking release

## Migration path

Once released, the easiest way is to modify your `Cargo.toml`, e.g.:

```
# Whether you use `bellman` or `bellman_ce`
bellman = { package = "zksync_bellman", version = "0.30.0" }
```