### PR TITLE
feat(bellman): Remove allocator feature from default features

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -1,0 +1,40 @@
+name: "Build stable"
+on:
+  pull_request:
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - ".github/workflows/ci.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: "always"
+  CARGO_INCREMENTAL: "0"
+  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  build_stable:
+    name: Build (stable)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          # Remove default `-D warnings`. This is a temporary measure.
+          rustflags: ""
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
+      # Bellman crate *must* build on stable, because parts of the core
+      # codebase are only used in the context of stable compiler.
+      - name: Build
+        run: |
+          cargo build -p zksync_bellman

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,3 +50,18 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run --no-fail-fast
+
+  ci-success:
+    name: Github Status Check
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+    needs: [ build ]
+    steps:
+      - name: Status
+        run: |
+          # This will check all jobs status in the `needs` list, and fail job if one is failed.
+          # Since we split prover and core to different flows, this job will be only as Required Status Check in the Pull Request.
+          if [[ ${{ contains(join(needs.*.result, ','), 'failure') }} == "true" ]]; then
+            echo "Intentionally failing to block PR from merging"
+            exit 1
+          fi

--- a/crates/bellman/Cargo.toml
+++ b/crates/bellman/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = { version = "1", optional = true }
 hex = "0.4"
 
 [features]
-default = ["multicore", "plonk", "allocator"]
+default = ["multicore", "plonk"]
 multicore = ["crossbeam", "futures/thread-pool"]
 sonic = ["tiny-keccak", "blake2-rfc"]
 gm17 = []

--- a/crates/fflonk/Cargo.toml
+++ b/crates/fflonk/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 description = "Reference implementation of fflonk prover and verifier"
 
 [dependencies]
-franklin-crypto.workspace = true
+franklin-crypto = { workspace = true, features = ["allocator"] }
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 rand = "0.4"

--- a/crates/franklin-crypto/Cargo.toml
+++ b/crates/franklin-crypto/Cargo.toml
@@ -14,7 +14,7 @@ description = "Cryptographic library for SNARK gadgets, based on sapling-crypto"
 crate-type = ["lib", "staticlib"]
 
 [features]
-default = ["multicore", "plonk", "allocator"]
+default = ["multicore", "plonk"]
 multicore = ["bellman/multicore"]
 plonk = ["bellman/plonk"]
 allocator = ["bellman/allocator"]


### PR DESCRIPTION
Recently `allocator` was added to default features in `bellman`, which made it heavily dependent on nightly compiler.
We have code that should compile with stable, so this PR removes `allocator` from default features.
Where needed, it can be enabled explicitly.