### PR TITLE
refactor: Remove `const_slice_index` feature gate

### DIFF
--- a/crates/boojum/rust-toolchain.toml
+++ b/crates/boojum/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-01"
+# channel = "nightly-2024-08-01"
+channel = "nightly"

--- a/crates/boojum/src/lib.rs
+++ b/crates/boojum/src/lib.rs
@@ -31,7 +31,6 @@
 #![feature(const_swap)]
 #![feature(inline_const)]
 #![feature(slice_swap_unchecked)]
-#![feature(const_slice_index)]
 #![feature(core_intrinsics)]
 #![feature(const_eval_select)]
 #![feature(get_mut_unchecked)]


### PR DESCRIPTION
The feature gate was removed in
https://github.com/rust-lang/rust/pull/130101/commits/7a3a317618885a8949c8b95c9a38f3f9729b1f3c