### PR TITLE
fix(snark-wrapper):  range check bitlen in snark wrapper circuit

### DIFF
--- a/crates/franklin-crypto/src/plonk/circuit/goldilocks/mod.rs
+++ b/crates/franklin-crypto/src/plonk/circuit/goldilocks/mod.rs
@@ -47,6 +47,10 @@ impl<E: Engine> Hash for GoldilocksField<E> {
 }
 
 pub fn range_check_for_num_bits<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, num: &Num<E>, num_bits: usize) -> Result<(), SynthesisError> {
+    range_check_for_num_bits_coarsely(cs, num, num_bits, true)
+}
+
+pub fn range_check_for_num_bits_coarsely<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, num: &Num<E>, num_bits: usize, coarsely: bool) -> Result<(), SynthesisError> {
     assert!(num_bits % 16 == 0);
 
     if let Num::Constant(value) = num {
@@ -56,7 +60,7 @@ pub fn range_check_for_num_bits<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS,
     } else {
         // Name of the table should be checked
         if let Ok(table) = cs.get_table(BITWISE_LOGICAL_OPS_TABLE_NAME) {
-            enforce_range_check_using_bitop_table(cs, &num.get_variable(), num_bits, table, true)?;
+            enforce_range_check_using_bitop_table(cs, &num.get_variable(), num_bits, table, coarsely)?;
         } else if <CS::Params as PlonkConstraintSystemParams<E>>::CAN_ACCESS_NEXT_TRACE_STEP {
             enforce_range_check_using_naive_approach(cs, &num.get_variable(), num_bits)?;
         } else {

--- a/crates/franklin-crypto/src/plonk/circuit/goldilocks/mod.rs
+++ b/crates/franklin-crypto/src/plonk/circuit/goldilocks/mod.rs
@@ -47,10 +47,6 @@ impl<E: Engine> Hash for GoldilocksField<E> {
 }
 
 pub fn range_check_for_num_bits<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, num: &Num<E>, num_bits: usize) -> Result<(), SynthesisError> {
-    range_check_for_num_bits_coarsely(cs, num, num_bits, true)
-}
-
-pub fn range_check_for_num_bits_coarsely<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, num: &Num<E>, num_bits: usize, coarsely: bool) -> Result<(), SynthesisError> {
     assert!(num_bits % 16 == 0);
 
     if let Num::Constant(value) = num {
@@ -60,7 +56,7 @@ pub fn range_check_for_num_bits_coarsely<E: Engine, CS: ConstraintSystem<E>>(cs:
     } else {
         // Name of the table should be checked
         if let Ok(table) = cs.get_table(BITWISE_LOGICAL_OPS_TABLE_NAME) {
-            enforce_range_check_using_bitop_table(cs, &num.get_variable(), num_bits, table, coarsely)?;
+            enforce_range_check_using_bitop_table(cs, &num.get_variable(), num_bits, table, true)?;
         } else if <CS::Params as PlonkConstraintSystemParams<E>>::CAN_ACCESS_NEXT_TRACE_STEP {
             enforce_range_check_using_naive_approach(cs, &num.get_variable(), num_bits)?;
         } else {

--- a/crates/snark-wrapper/src/verifier/mod.rs
+++ b/crates/snark-wrapper/src/verifier/mod.rs
@@ -201,9 +201,12 @@ fn aggregate_public_inputs<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, publ
     );
 
     // Firstly we check that public inputs have correct size
-    use rescue_poseidon::franklin_crypto::plonk::circuit::goldilocks::range_check_for_num_bits_coarsely;
     for pi in public_inputs.iter() {
-        range_check_for_num_bits_coarsely(cs, &pi.into_num(), 64, false)?;
+        if let Ok(_) = cs.get_table(BITWISE_LOGICAL_OPS_TABLE_NAME) {
+            range_check_with_lookup(cs, &pi.into_num(), chunk_bit_size)?;
+        } else {
+            range_check_with_naive(cs, &pi.into_num(), chunk_bit_size)?;
+        }
     }
 
     // compute aggregated pi value
@@ -228,4 +231,18 @@ fn aggregate_public_inputs<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, publ
     lc.enforce_zero(cs)?;
 
     Ok(pi)
+}
+
+pub fn range_check_with_naive<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, num: &Num<E>, num_bits: usize) -> Result<(), SynthesisError> {
+    use rescue_poseidon::franklin_crypto::plonk::circuit::goldilocks::range_check_for_num_bits;
+    range_check_for_num_bits(cs, num, num_bits)?;
+
+    Ok(())
+}
+
+pub fn range_check_with_lookup<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, num: &Num<E>, num_bits: usize) -> Result<(), SynthesisError> {
+    let table = cs.get_table(BITWISE_LOGICAL_OPS_TABLE_NAME).unwrap();
+    use rescue_poseidon::franklin_crypto::plonk::circuit::bigint_new::enforce_range_check_using_bitop_table;
+    enforce_range_check_using_bitop_table(cs, &num.get_variable(), num_bits, table, false)?;
+    Ok(())
 }

--- a/crates/snark-wrapper/src/verifier/mod.rs
+++ b/crates/snark-wrapper/src/verifier/mod.rs
@@ -201,9 +201,9 @@ fn aggregate_public_inputs<E: Engine, CS: ConstraintSystem<E>>(cs: &mut CS, publ
     );
 
     // Firstly we check that public inputs have correct size
-    use rescue_poseidon::franklin_crypto::plonk::circuit::goldilocks::range_check_for_num_bits;
+    use rescue_poseidon::franklin_crypto::plonk::circuit::goldilocks::range_check_for_num_bits_coarsely;
     for pi in public_inputs.iter() {
-        range_check_for_num_bits(cs, &pi.into_num(), 64)?;
+        range_check_for_num_bits_coarsely(cs, &pi.into_num(), 64, false)?;
     }
 
     // compute aggregated pi value


### PR DESCRIPTION
This PR fixes bitlen in a snark wrapper circuit that was causing vk divergency of wrapper circuit made for plonk based prover.