### PR TITLE
Update for Montgomery Inverse

### DIFF
--- a/crates/fflonk/src/definitions/proof.rs
+++ b/crates/fflonk/src/definitions/proof.rs
@@ -8,7 +8,7 @@ pub struct FflonkProof<E: Engine, C: Circuit<E>> {
     pub inputs: Vec<E::Fr>,
     pub commitments: Vec<E::G1Affine>,
     pub evaluations: Vec<E::Fr>,
-    pub lagrange_basis_inverses: Vec<E::Fr>,
+    pub montgomery_inverse: E::Fr, 
     _c: std::marker::PhantomData<C>,
 }
 
@@ -31,7 +31,7 @@ impl<E: Engine, C: Circuit<E>> FflonkProof<E, C> {
             inputs: vec![],
             commitments: vec![],
             evaluations: vec![],
-            lagrange_basis_inverses: vec![],
+            montgomery_inverse: E::Fr::zero(),
             _c: std::marker::PhantomData,
         }
     }
@@ -40,7 +40,7 @@ impl<E: Engine, C: Circuit<E>> FflonkProof<E, C> {
             inputs,
             commitments,
             evaluations,
-            lagrange_basis_inverses,
+            montgomery_inverse,
             ..
         } = self;
 
@@ -55,8 +55,7 @@ impl<E: Engine, C: Circuit<E>> FflonkProof<E, C> {
         let mut serialized_proof = fe_slice_into_be_byte_array(&flattened_commitments);
 
         serialized_proof.extend(fe_slice_into_be_byte_array(evaluations));
-        serialized_proof.extend(fe_slice_into_be_byte_array(lagrange_basis_inverses));
-
+        serialized_proof.extend(fe_slice_into_be_byte_array(&[montgomery_inverse.clone()]));
         (serialized_inputs, serialized_proof)
     }
 }

--- a/crates/fflonk/src/prover.rs
+++ b/crates/fflonk/src/prover.rs
@@ -952,7 +952,7 @@ pub fn create_proof<E: Engine, C: Circuit<E>, P: PlonkConstraintSystemParams<E>,
     // draw challenge for L(x)
     let y = transcript.get_challenge();
 
-    let (flattened_lagrange_basis_inverses, lagrange_basis_evaluations) = precompute_all_lagrange_basis_evaluations(
+    let (montgomery_inverse, lagrange_basis_evaluations) = precompute_all_lagrange_basis_evaluations(
         interpolation_size_of_setup,
         interpolation_size_of_first_round,
         interpolation_size_of_second_round,
@@ -962,6 +962,7 @@ pub fn create_proof<E: Engine, C: Circuit<E>, P: PlonkConstraintSystemParams<E>,
         y,
         setup_evaluations.requires_opening_at_shifted_point(),
         first_round_evaluations.requires_opening_at_shifted_point(),
+        None,
     );
 
     // L(x) = Z_{T\S0}(y)*(C0(x)- r0(y)) + alpha*Z_{T\S1}(y)*(C1(x)- r1(y)) + alpha^2*Z_{T\S2}(y)*(C2(x)- r2(y)) - Z_T(y)*W(x)
@@ -1038,7 +1039,7 @@ pub fn create_proof<E: Engine, C: Circuit<E>, P: PlonkConstraintSystemParams<E>,
     proof.inputs = input_values.clone();
     proof.evaluations = all_evaluations;
     proof.commitments = vec![c1_commitment, c2_commitment, w_commitment, w_prime_commitment];
-    proof.lagrange_basis_inverses = flattened_lagrange_basis_inverses;
+    proof.montgomery_inverse = montgomery_inverse;
 
     Ok(proof)
 }

--- a/crates/fflonk/src/verifier.rs
+++ b/crates/fflonk/src/verifier.rs
@@ -221,7 +221,7 @@ pub fn verify<E: Engine, C: Circuit<E>, T: Transcript<E::Fr>>(
         num_second_round_polys,
         proof.evaluations.to_vec(),
         recomputed_quotients,
-        &proof.lagrange_basis_inverses,
+        proof.montgomery_inverse,
         c1,
         c2,
         w,
@@ -242,7 +242,7 @@ fn aggregate_points_and_check_pairing<E: Engine, C: Circuit<E>>(
     num_second_round_polys: usize,
     all_evaluations: Vec<E::Fr>,
     recomputed_quotient_evaluations: RecomptuedQuotientEvaluations<E::Fr>,
-    lagrange_basis_inverses: &[E::Fr],
+    montgomery_inverse: E::Fr,
     c1: E::G1Affine,
     c2: E::G1Affine,
     w: E::G1Affine,
@@ -335,8 +335,7 @@ fn aggregate_points_and_check_pairing<E: Engine, C: Circuit<E>>(
     // of the system polynomials
     // Since evaluation sets are not constant, rather than lagrange interpolation
     // barycentric interpolation is utilized here.
-    let precomputed_basis_evals = precompute_all_lagrange_basis_evaluations_from_inverses(
-        lagrange_basis_inverses,
+    let (_, precomputed_basis_evals) = precompute_all_lagrange_basis_evaluations(
         interpolation_size_of_setup,
         interpolation_size_of_first_round,
         interpolation_size_of_second_round,
@@ -346,6 +345,7 @@ fn aggregate_points_and_check_pairing<E: Engine, C: Circuit<E>>(
         y,
         setup_requires_opening_at_shifted_point,
         first_round_requires_opening_at_shifted_point,
+        Some(montgomery_inverse),
     );
 
     let [setup_r_at_y, mut first_round_r_at_y, mut second_round_r_at_y] = evaluate_r_polys_at_point_with_flattened_evals_and_precomputed_basis(


### PR DESCRIPTION
Updates for the Prover and Verifier:
Instead of sending Lagrange Nasis Inverses with the proof, the prover now creates the proof with one consolidated Montgomery Inverse. The Verifier has been updated with the corresponding changes as well.