### PR TITLE
fix(boojum): Fixed issue with FFProxy serialization

### DIFF
--- a/crates/boojum/src/gadgets/non_native_field/implementations/implementation_u16.rs
+++ b/crates/boojum/src/gadgets/non_native_field/implementations/implementation_u16.rs
@@ -1142,9 +1142,6 @@ where
             type Value = FFProxyValue<T, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                {
-                    eprintln!("Stacktrace: {:?}", std::backtrace::Backtrace::capture());
-                }
                 formatter.write_str("a valid PrimeField value")
             }
 


### PR DESCRIPTION
Fixed issue with FFProxy serialization.

Bincode was depending on a different method serialization method (visit_seq) than json, which was not implemented.

Also added tests. 