### PR TITLE
chore: Update rust-toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,6 @@ env:
   CARGO_INCREMENTAL: "0"
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
-  # Rust version to use.
-  nightly: nightly-2024-08-01
 
 jobs:
   build:

--- a/crates/boojum/src/dag/guide.rs
+++ b/crates/boojum/src/dag/guide.rs
@@ -843,8 +843,14 @@ impl<T: Debug, F: SmallField, Cfg: CSResolverConfig> BufferGuide<T, F, Cfg> {
 impl<T: Copy + Debug, F: SmallField, Cfg: CSResolverConfig> Guide<T, F, Cfg>
     for BufferGuide<T, F, Cfg>
 {
-    type PushOrder<'a>         = BufferGuideOrder       <'a, T, F, Cfg> where T: 'a;
-    type FinalizationOrder<'a> = BufferGuideFinalization<'a, T, F, Cfg> where T: 'a;
+    type PushOrder<'a>
+        = BufferGuideOrder<'a, T, F, Cfg>
+    where
+        T: 'a;
+    type FinalizationOrder<'a>
+        = BufferGuideFinalization<'a, T, F, Cfg>
+    where
+        T: 'a;
 
     fn push(
         &mut self,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-08-01"
+channel = "nightly-2025-03-19"


### PR DESCRIPTION
The older compiler is no longer working for some of our dependencies:

error: extern block cannot be declared unsafe
Error:    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.75/src/backtrace/libunwind.rs:173:5
