### PR TITLE
ci(release-please,publish-crates): bump reusable CI versions and remove deprecated inputs

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -17,11 +17,6 @@ on:
         description: 'Run tests before release.'
         required: false
         default: false
-      org-owner:
-        type: string
-        description: 'Organization to add as owner of the crates.'
-        required: false
-        default: 'github:matter-labs:crates-io'
 
 
 jobs:
@@ -29,13 +24,14 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     runs-on: matterlabs-ci-runner-highdisk
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Publish crates
-        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@v1
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@c488e5a187bfa5b667ec31061045be3ad7f3245a
         with:
           slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }} # Slack webhook for notifications
-          cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }} # Crates.io token for publishing
-          org_owner: ${{ inputs.org-owner }}
           run_build: ${{ inputs.run-build }}
           run_tests: ${{ inputs.run-tests }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,11 +20,10 @@ jobs:
 
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@v1
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
       gh_token: ${{ secrets.RELEASE_TOKEN }}
-      cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}
     with:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ ignore = [
     "RUSTSEC-2024-0436", # paste (1.0.15) is unmaintained
     "RUSTSEC-2024-0370", # proc-macro-error (1.0.4) is unmaintained
     "RUSTSEC-2021-0127", # serde-cbor (0.11.2) is unmaintained
+    "RUSTSEC-2022-0104", # structopt (0.3.26) is unmaintained
 ]
 
 [licenses]


### PR DESCRIPTION
## What ❔

- update versions of reusable workflows used to publish crates to crates.io. New version of those workflows use trusted publishing instead of static API tokens
- due to the limitation of trusted publishing, new crates in crates.io will have to be initially created by DevOps:
> Your crate must already be published to crates.io (initial publish requires an API token)

## Why ❔

- trusted publishing replaces long-lived crates.io API tokens with short-lived, OIDC-issued credentials scoped to a specific repo and workflow. This removes a standing secret that could leak and would need manual rotation, and follows crates.io's recommended publishing setup.

---
reusable CI changes: https://github.com/matter-labs/zksync-ci-common/pull/51/changes