### PR TITLE
chore: bump nightly to 2026-08-09

### DIFF
--- a/crates/boojum/profiling-target/rust-toolchain.toml
+++ b/crates/boojum/profiling-target/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-08-09"
+channel = "nightly-2025-10-20"

--- a/crates/boojum/profiling-target/rust-toolchain.toml
+++ b/crates/boojum/profiling-target/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-10-20"
+channel = "nightly-2026-08-09"

--- a/crates/boojum/profiling-target/rust-toolchain.toml
+++ b/crates/boojum/profiling-target/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-08-09"

--- a/crates/boojum/rust-toolchain.toml
+++ b/crates/boojum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-08-09"
+channel = "nightly-2025-10-20"

--- a/crates/boojum/rust-toolchain.toml
+++ b/crates/boojum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-10-20"
+channel = "nightly-2026-08-09"

--- a/crates/boojum/rust-toolchain.toml
+++ b/crates/boojum/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-# channel = "nightly-2024-08-01"
-channel = "nightly"
+channel = "nightly-2026-08-09"

--- a/crates/boojum/src/dag/resolver_box.rs
+++ b/crates/boojum/src/dag/resolver_box.rs
@@ -564,8 +564,6 @@ mod test {
         assert!(ins.iter().zip(value.inputs()).all(|(x, y)| { x == y }));
         assert!(out.iter().zip(value.outputs()).all(|(x, y)| { x == y }));
 
-        assert!(value.bind_fn_ptr() as *const _ as usize % 4 == 0);
-
         let bind_fn_exp_addr = bind_fn as *const u8 as usize;
         let bind_fn_act_addr = value.header.bind_fn_ref as *const u8 as usize;
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-01-22"
+channel = "nightly-2026-08-09"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-08-09"
+channel = "nightly-2025-10-20"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-10-20"
+channel = "nightly-2026-08-09"


### PR DESCRIPTION
Bumps the pinned toolchain from `nightly-2026-01-22` to **`nightly-2026-08-09`** (rustc 1.99.0-nightly, `771916f90`).

## Changes (4 files)

- `rust-toolchain`: `nightly-2026-01-22` → `nightly-2026-08-09`
- `crates/boojum/rust-toolchain.toml` and `crates/boojum/profiling-target/rust-toolchain.toml`: floating `nightly` → the same explicit date, so those nested crates build reproducibly instead of drifting with whatever nightly happens to be installed
- `crates/boojum/src/dag/resolver_box.rs`: removes one test assertion (below)

The `array_chunks` → `as_chunks` migration that newer nightlies require **already landed here** in cb466ac, so no migration work was needed.

## The removed assertion

`run_invariant_asserts` asserted that a function pointer is 4-byte aligned:

```rust
assert!(value.bind_fn_ptr() as *const _ as usize % 4 == 0);
```

That only holds on targets with fixed-width 4-byte instructions (aarch64, riscv). x86_64 has variable-length instructions and places function entry points at arbitrary addresses, so there it held only by chance of code layout — it held on `nightly-2025-10-20` and stopped holding on `nightly-2026-08-09` under `lto = "fat"` + `codegen-units = 1`. That failed `dag::resolver_box::test::{store_upholds_invariant_on_grow, storing_retreiving_upholds_invariant}` on the ubuntu runner, while the aarch64 runner could not observe it at all — the assertion is structurally unfalsifiable there.

**Nothing in `ResolverBox` depends on that alignment.** `bind_fn_ptr` is only transmuted back to a `fn` and called (`resolvers/st.rs:199`, `resolvers/mt/resolution_window.rs:738`), which has no alignment precondition. The 4-byte requirements in the non-test code (`loc % 4`, `f_ptr % align_of_val`) are about offsets and storage slots inside the box, not about where the bound function lives.

Removal was agreed with @shamatar rather than gating it per-arch.

## Verification

CI is green on both runners (**10/10**). Locally: `cargo check --workspace --all-targets` → 0 errors, the five `dag::resolver_box` tests pass in release, `cargo fmt --all --check` clean.

## Note for downstream

`boojum` is still version `0.32.10` here, identical to the copy on crates.io, so **the cb466ac fix remains unpublished**. Anything depending on published `boojum` (zksync-protocol, zksync-crypto-gpu) still pulls the pre-fix code and carries a temporary `[patch.crates-io]` until a `boojum > 0.32.10` ships. Cutting that release is what lets those PRs drop their patches.

Companion PRs: matter-labs/zksync-protocol#235, matter-labs/zksync-crypto-gpu#159, matter-labs/zksync-airbender#411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
